### PR TITLE
Fixed Sphinx build warnings

### DIFF
--- a/mathml.rst
+++ b/mathml.rst
@@ -127,7 +127,7 @@ See the `results of the MathML3.0 test suite
 
 
 Semantics and Annotations
-=====================
+=========================
 
 Starting with MathJax version 2.3, some popular annotation formats like TeX,
 Maple, or Content MathML that are often included in the MathML source via the


### PR DESCRIPTION
Currently Sphinx emits:

```
mathjax-docs/index.rst:29: WARNING: toctree contains reference to nonexisting document 'match-web-fonts'
mathjax-docs/mathml.rst:130: WARNING: Title underline too short.
mathjax-docs/platforms/movable-type.rst:: WARNING: document isn't included in any toctree
mathjax-docs/platforms/wordpress.rst:: WARNING: document isn't included in any toctree
```

This fixes all these issues.
