### PR TITLE
Small tweak to SVG.rst documentation file

### DIFF
--- a/options/SVG.rst
+++ b/options/SVG.rst
@@ -9,13 +9,12 @@ processor that is run when you include ``"output/SVG"`` in the
 `jax` array of your configuration or load a combined configuration
 file that includes the SVG output jax.  They are listed with their default
 values.  To set any of these options, include an ``SVG`` section
-in your :meth:`MathJax.Hub.Config()` call.  Note that, because of the
-dash, you need to enclose the name in quotes.  For example
+in your :meth:`MathJax.Hub.Config()` call.  For example
 
 .. code-block:: javascript
 
     MathJax.Hub.Config({
-      "SVG": {
+      SVG: {
         scale: 120
       }
     });


### PR DESCRIPTION
This seems to have been a copy-paste legacy from the HTML-CSS documentation, speaking of a dash (the one in HTML-CSS) that isn't present in the identifier SVG.
