### PR TITLE
Add missing MatchWebFonts block to configuration example

### DIFF
--- a/options/MatchWebFonts.rst
+++ b/options/MatchWebFonts.rst
@@ -14,13 +14,15 @@ For example
 .. code-block:: javascript
 
     MathJax.Hub.Config({
-      matchFor: {
-        "HTML-CSS": true,
-        NativeMML: false,
-        SVG: false
-      },
-      fontCheckDelay: 2000,
-      fontCheckTimeout: 30 * 1000
+      MatchWebFonts: {
+        matchFor: {
+          "HTML-CSS": true,
+          NativeMML: false,
+          SVG: false
+        },
+        fontCheckDelay: 2000,
+        fontCheckTimeout: 30 * 1000
+      }
     });
 
 would ask to apply font size matching for the `HTML-CSS` output mode


### PR DESCRIPTION
This fixes the example in the MatchWebFonts options page, which was missing the `MatchWebFonts` block around the options being configured.
