### PR TITLE
Fix syntax error in mathjax-node.rst

### DIFF
--- a/advanced/mathjax-node.rst
+++ b/advanced/mathjax-node.rst
@@ -9,7 +9,7 @@ library.
 
 To install via NPM use
 
-..code-block:: bash
+.. code-block:: bash
 
   npm install mathjax-node
 


### PR DESCRIPTION
`..code-block::` → `.. code-block::`