### PR TITLE
Update configuration.rst

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -31,7 +31,7 @@ web server's directory hierarchy, you might use
 
 .. code-block:: html
 
-    <script type="text/javascript" src="/MathJax/MathJax.js"></script>
+    <script type="text/javascript" src="/MathJax/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 to load MathJax.
 


### PR DESCRIPTION
I am using a local copy of MathJax.js on files containing ASCIIMathML syntax. They do not render without adding ?config=TeX-MML-AM_CHTML. To be consistent with the src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"> directive, and to make sure it works with a local copy, this should be added to the doc.