### PR TITLE
Added another site using MathJax

### DIFF
--- a/misc/mathjax-in-use.rst
+++ b/misc/mathjax-in-use.rst
@@ -239,6 +239,7 @@ Contact us about your site and we’ll mention you in our
 **Search**
 
 -  `SearchOnMath.com <http://www.searchonmath.com/>`__
+-  `Approach0.xyz <http://approach0.xyz/>`__
 
 **Blogs&personal websites** [early adoptors for historic purposes only]
 


### PR DESCRIPTION
I know *Gallery of Selected Sites* is closed from editing, but my site really fit into the galley of *search*. 

Is that possible to enlist my side-project under this section? If not, could someone mention it on your community news blog?

Thanks!