### PR TITLE
update CDN references

### DIFF
--- a/_static/mathjax_mathml.user.js
+++ b/_static/mathjax_mathml.user.js
@@ -11,7 +11,7 @@ if ((window.unsafeWindow == null ? window : unsafeWindow).MathJax == null) {
       (document.getElementsByTagNameNS("http://www.w3.org/1998/Math/MathML","math").length > 0))) {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
+    script.src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
     var config = 'MathJax.Hub.Startup.onload()';
     document.getElementsByTagName("head")[0].appendChild(script);
   }

--- a/_static/mathjax_wikipedia.user.js
+++ b/_static/mathjax_wikipedia.user.js
@@ -24,7 +24,7 @@ if ((window.unsafeWindow == null ? window : unsafeWindow).MathJax == null) {
     //
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
+    script.src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
     document.getElementsByTagName("head")[0].appendChild(script);
   }
 }

--- a/advanced/debugging-tips.rst
+++ b/advanced/debugging-tips.rst
@@ -12,13 +12,13 @@ Using unpacked resources
 
 MathJax provides both packged (minified) and unpacked versions of all its components. For debugging, it is useful to switch to an unpacked versions.
 
-For example, using the MathJax CDN just add `unpacked/` before `MathJax.js`, e.g., from
+For example, if your copy of MathJax lives at `https://example.com/MathJax.js` just add `unpacked/` before `MathJax.js`, e.g.,
 
 
 .. code-block:: html
 
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+      src="https://example.com/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
 
 to
@@ -27,7 +27,7 @@ to
 .. code-block:: html
 
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/unpacked/MathJax.js?config=TeX-MML-AM_CHTML">
+      src="https://example.com/unpacked/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
 
 

--- a/advanced/dynamic.rst
+++ b/advanced/dynamic.rst
@@ -24,7 +24,7 @@ Here is an example of how to load and configure MathJax dynamically:
     (function () {
       var script = document.createElement("script");
       script.type = "text/javascript";
-      script.src  = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+      script.src  = "https://example.com/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
       document.getElementsByTagName("head")[0].appendChild(script);
     })();
 
@@ -44,7 +44,7 @@ MathJax's configuration script:
       head.appendChild(script);
       script = document.createElement("script");
       script.type = "text/javascript";
-      script.src  = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+      script.src  = "https://example.com/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
       head.appendChild(script);
     })();
 
@@ -106,7 +106,7 @@ IE+MathPlayer.
           (document.getElementsByTagNameNS("http://www.w3.org/1998/Math/MathML","math").length > 0))) {
         var script = document.createElement("script");
         script.type = "text/javascript";
-        script.src = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
+        script.src = "https://example.com/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
         document.getElementsByTagName("head")[0].appendChild(script);
       }
     }
@@ -146,7 +146,7 @@ converting the math images to their original TeX code.
         //
         var script = document.createElement("script");
         script.type = "text/javascript";
-        script.src = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
+        script.src = "https://example.com/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full";
         document.getElementsByTagName("head")[0].appendChild(script);
       }
     }

--- a/advanced/signals.rst
+++ b/advanced/signals.rst
@@ -104,7 +104,7 @@ called when it arrives.  For example
 See the :ref:`MathJax Startup Sequence <startup-sequence>` page for
 details of the messages sent during startup.  See also the
 `test/sample-signals.html
-<http://cdn.mathjax.org/mathjax/latest/test/sample-signals.html>`_
+<https://github.com/mathjax/MathJax/tree/master/test/sample-signals.html>`_
 file (and its source) for examples of using signals.  This example
 lists all the signals that occur while MathJax is processing that
 page, so it gives useful information about the details of the signals
@@ -157,7 +157,7 @@ signal's :meth:`Interest()` method, as in the following example.
 This will cause an alert for every signal that MathJax produces.  You
 probably don't want to try this out, since it will produce a *lot* of
 them; instead, use the `test/sample-signals.html
-<http://cdn.mathjax.org/mathjax/latest/test/sample-signals.html>`_
+<https://github.com/mathjax/MathJax/tree/master/test/sample-signals.html>`_
 file, which displays them in the web page.
 
 See the :ref:`Signal Object <api-signal>` reference page for details on the

--- a/advanced/startup.rst
+++ b/advanced/startup.rst
@@ -190,5 +190,5 @@ Extensions` will depend on the files being loaded.)  Both 6 and 7 must
 complete, however, before 8 will be performed.
 
 See the `test/sample-signals.html
-<http://cdn.mathjax.org/mathjax/latest/test/sample-signals.html>`_ file
+<https://github.com/mathjax/MathJax/tree/master/test/sample-signals.html>`_ file
 to see the signals in action.

--- a/advanced/synchronize.rst
+++ b/advanced/synchronize.rst
@@ -51,7 +51,7 @@ type of signal and that signal has already occurred, you will be told
 about the past occurrences as well as any future ones.  See the
 :ref:`Signal Object <api-signal>` reference page for more details.
 See also the `test/sample-signals.html
-<http://cdn.mathjax.org/mathjax/latest/test/sample-signals.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/sample-signals.html>`_
 file in the MathJax ``test`` directory for a working example of using
 signals.
 

--- a/advanced/toMathML.rst
+++ b/advanced/toMathML.rst
@@ -83,7 +83,7 @@ Here is a complete example:
         }
       );
     </script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
+    <script type="text/javascript" src="http://example.com/MathJax.js?config=TeX-AMS_HTML-full"></script>
     </head>
     <body>
     <p>

--- a/advanced/typeset.rst
+++ b/advanced/typeset.rst
@@ -189,7 +189,7 @@ however, that Internet Explorer does not fire the ``onchange`` event
 when you press RETURN, so this example does not work as expected in
 IE.  A more full-featured version that addresses this problem is
 available in `test/sample-dynamic.html
-<http://cdn.mathjax.org/mathjax/latest/test/sample-dynamic.html>`_.
+<https://github.com/mathjax/MathJax/blob/master/test/sample-dynamic.html>`_.
 
 .. code-block:: html
 
@@ -205,7 +205,7 @@ available in `test/sample-dynamic.html
       });
     </script>
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full">
+      src="https://example.com/MathJax.js?config=TeX-AMS_HTML-full">
     </script>
 
     </head>
@@ -249,7 +249,7 @@ available in `test/sample-dynamic.html
     </html>
 
 There are a number of additional example pages at `test/examples.html
-<http://cdn.mathjax.org/mathjax/latest/test/examples.html>`_ that
+<https://github.com/mathjax/MathJax/blob/master/test/examples.html>`_ that
 illustrate how to call MathJax dynamically or perform other actions
 with MathJax.
 

--- a/config-files.rst
+++ b/config-files.rst
@@ -17,7 +17,7 @@ it via
 where ``path-to-MathJax`` is the URL to the MathJax directory on your
 server or hard disk.  If you are using MathJax from the CDN, you can
 view the contents of `default.js
-<http://cdn.mathjax.org/mathjax/latest/config/default.js>`_ as a
+<https://github.com/mathjax/MathJax/blob/master/config/default.js>`_ as a
 reference, but you will not be able to edit the CDN copy.  It is
 possible to use the CDN copy of MathJax with your own configuration
 file, however; see :ref:`Using a Local Configuration File with the CDN

--- a/configuration.rst
+++ b/configuration.rst
@@ -14,13 +14,13 @@ section of your document:
     <script type="text/javascript" src="path-to-MathJax/MathJax.js"></script>
 
 where ``path-to-MathJax`` is replaced by the URL of the copy of MathJax
-that you are loading.  For example, if you are using the MathJax
+that you are loading.  For example, if you are using `cdnjs <https://cdnjs.com>`_ as a
 distributed network service, the tag might be
 
 .. code-block:: html
 
     <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js">
+       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js">
     </script>
 
 If you have installed MathJax yourself, ``path-to-MathJax`` will be the
@@ -49,7 +49,7 @@ typical invocation of MathJax would be
 .. code-block:: html
 
     <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
 
 which loads MathJax with a configuration file that includes everything
@@ -79,76 +79,51 @@ advanced topic, however; see :ref:`Loading MathJax Dynamically
 
 .. _loading-CDN:
 
-Loading MathJax from the CDN
-============================
+Loading MathJax from a CDN
+==========================
 
-MathJax is available as a web service from ``cdn.mathjax.org``, so you
+MathJax is available as a web service from various free CDN providers, so you
 can obtain MathJax from there without needing to install it on your own
-server.  The CDN is part of a distributed "cloud" network, so it is
+server.  
+
+.. warning:: 
+
+  We retired our self-hosted CDN at `cdn.mathjax.org` in April, 2017.
+  We recommend using `cdnjs.com <cdnjs.com>`_ which uses the same provider.
+  The use of ``cdn.mathjax.org`` was governed by its `terms of service
+  <https://www.mathjax.org/mathjax-cdn-terms-of-service/>`_.
+
+
+
+A CDN is part of a distributed "cloud" network, so it is
 handled by servers around the world.  That means that you should get access
 to a server geographically near you, for a fast, reliable connection.
 
-The CDN hosts the most current version of MathJax, as well as older
-versions, so you can either link to a version that stays up-to-date as
-MathJax is improved, or you can stay with one of the release versions so
-that your pages always use the same version of MathJax.
+Most CDN services offer several versions of MathJax. For example, `cdnjs` 
+hosts all tagged versions since v1.1 so you can link to the version
+you prefer. 
+
+.. note:: 
+
+  There is currently no provider who offers a rolling release link, i.e,
+  a link that updates to each newer version of MathJax upon release.
 
 The URL that you use to obtain MathJax determines the version that you
-get.  The CDN has the following directory structure:
+get. For example, `cdnjs` uses a URL that includes the version tag so 
+you can load the current version via
 
 .. code-block::  sh
 
-    mathjax/         # project-name
-       1.0-latest/
-       1.1-latest/   # the 1.1 release with any critical patches
-       2.0-latest/   # the 2.0 release with any critical patches
-       2.1-latest/   # the 2.1 release with any critical patches
-       2.2-latest/   # the 2.2 release with any critical patches
-       2.3-latest/   # the 2.3 release with any critical patches
-       2.4-latest/   # the 2.4 release with any critical patches
-       2.5-latest/   # the 2.5 release with any critical patches
-       2.6-latest/   # the 2.6 release with any critical patches
-       2.7-latest/   # the 2.7 release with any critical patches
-       ...
-       latest/       # the most current version (2.6-latest in this case)
+  https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js   # the 2.7.0 release
 
-Each directory corresponds to an official MathJax release; however,
-hotfixes (urgent bug fixes) will be applied in each release branch as
-necessary, even if new releases are not prepared.  In other words,
-``1.1-latest`` will initially point to v1.1, but over time may be updated
-with patches that would correspond to releases that might be numbers 1.1a,
-1.1b, etc., even if such releases are not actually packaged for
-separate distribution (they likely won't be).
-We may occasionally introduce directories for betas, as indicated above,
-but they will be temporary, and will be removed after the official
-release.
+Pre-releases are also available on `cdnjs`.
 
-To load from a particular release, use the directory for that release.
-For example,
+.. note:: 
+  If you wish to use the development version of
+  MathJax, you will need to install your own copy; see :ref:`Installing
+  and Testing MathJax <installation>` for information on how to do that.
 
-.. code-block:: html
-
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.0-latest/MathJax.js"></script>
-
-loads the v2.0 version, even after v2.1 or later
-versions are released, while
-
-.. code-block:: html
-
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
-
-will always be the most current stable release, so it will go from v2.3 to
-the next version automatically when that is released.  Note that all the versions
-available on the CDN are stable versions; the development version is not
-hosted on the CDN.  (If you wish to use the development version of
-MathJax, you will need to install your own copy; see :ref:`Installing
-and Testing MathJax <installation>` for information on how to do that.)
-
-The use of ``cdn.mathjax.org`` is governed by its `terms of service
-<https://www.mathjax.org/mathjax-cdn-terms-of-service/>`_, so be
-sure to read that before linking to the MathJax CDN server.
-
-If you wish to use the MathJax CDN but use your own configuration file
+If you wish to use a CDN but use your own configuration file
 rather than one of the pre-defined ones, see the information at the
 end of the :ref:`Using a Local Configuration File
 <local-config-files>` section below.
@@ -225,7 +200,7 @@ the ``MathJax.js`` file.  For example
 .. code-block:: html
 
     <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_CHTML">
+       src="https://example.com/MathJax.js?config=TeX-AMS-MML_CHTML">
     </script>
 
 loads the ``config/TeX-AMS-MML_HTMLorMML.js`` configuration file from the
@@ -248,19 +223,19 @@ to first load the main configuration, then the local modifications.
 
 .. _local-config-files:
 
-Using a local configuration file with the CDN
-=============================================
+Using a local configuration file with a CDN
+===========================================
 
-You can load MathJax from the MathJax CDN server but still use a
+You can load MathJax from a CDN provider but still use a
 configuration from your own local server.  For example, suppose you
 have a configuration file called ``local.js`` on your own server, in a
 directory called ``MathJax/config/local``.  Then you can load MathJax
-from the CDN and still use your configuration file as follows:
+from a CDN and still use your configuration file as follows:
 
 .. code-block:: html
 
     <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,http://myserver.com/MathJax/config/local/local.js">
+       src="https://example.com/MathJax.js?config=TeX-AMS_HTML,http://myserver.com/MathJax/config/local/local.js">
     </script>
 
 Because the ``local.js`` file is not on the CDN server, you must give

--- a/jsMath.rst
+++ b/jsMath.rst
@@ -30,7 +30,7 @@ example,
       });
     </script>
     <script
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://example.com/MathJax.js?config=TeX-AMS_HTML">
     </script>
 
 would load the ``jsMath2jax`` preprocessor, along with a configuration 

--- a/localization.rst
+++ b/localization.rst
@@ -32,7 +32,7 @@ example:
 
 .. code-block:: html
 
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML&locale=fr"></script>
+    <script src="https://example.com/MathJax.js?config=TeX-AMS_HTML&locale=fr"></script>
 
 will load MathJax using the French language.  Users can still override
 this setting using the `Language` submenu of the MathJax contextual
@@ -43,5 +43,5 @@ If you want to help in the translation process, please visit the
 `TranslateWiki.net interface
 <https://translatewiki.net/wiki/Translating:MathJax>`_.  The page
 `localization.html
-<http://cdn.mathjax.org/mathjax/latest/test/localization.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/localization.html>`_
 is a convenient way to check the different translations.

--- a/misc/faq.rst
+++ b/misc/faq.rst
@@ -166,11 +166,7 @@ problem, please follow these steps:
    problems there as well. This might help you to determine the nature
    of your problem.
 -  If possible, check whether the problem has been solved in the latest
-   MathJax release. The preferred way to do this is to invoke the most
-   recent version of MathJax on the CDN by pointing to
-   https://cdn.mathjax.org/mathjax/latest/MathJax.js. If you need to work
-   locally, try a fresh install of the `latest
-   release <https://www.mathjax.org/download/>`__.
+   MathJax release, cf. :ref:`the installation instructions <installation>`.
 -  Search through the `MathJax User
    Group <https://groups.google.com/group/mathjax-users>`__ to see if
    anyone else has come across the problem before.

--- a/misc/platforms.rst
+++ b/misc/platforms.rst
@@ -97,10 +97,10 @@ you are not, you may need to have an administrator do these steps for
 you. You will also have to identify the right file if the theme
 consists of multiple files.
 
-To enable MathJax in your web platform, add the line::
+To enable MathJax in your web platform using cdnjs, add the line:
 
     <script type="text/javascript" 
-       src="httpsp://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 either just before the ``</head>`` tag in your theme file, or at the end of
 the file if it contains no ``</head>``. 

--- a/options/TeX.rst
+++ b/options/TeX.rst
@@ -88,7 +88,7 @@ to be defined within the TeX input processor.
         ``false``, use the equation number.
 
     See the `MathJax examples page
-    <http://cdn.mathjax.org/mathjax/latest/test/examples.html>`_ for
+    <https://github.com/mathjax/MathJax/blob/master/test/examples.html>`_ for
     some examples of equation numbering.
     
 .. describe:: Macros: {}

--- a/safe-mode.rst
+++ b/safe-mode.rst
@@ -55,7 +55,7 @@ to add ``,Safe`` after the configuration file when you are loading
 
 .. code-block:: html
 
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe"></script>
+    <script src="https://example.com/MathJax.js?config=TeX-AMS_HTML,Safe"></script>
 
 This causes MathJax to load the ``TeX-AMS_HTML`` configuration file,
 and then the ``Safe`` configuration, which adds the Safe extension to
@@ -73,7 +73,7 @@ include ``"Safe.js"`` in your ``extensions`` array directly:
       extensions: ["tex2jax.js","Safe.js"]
     });
     </script>
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    <script src="https://example.com/MathJax.js"></script>
 
 The Safe extension has a number of configuration options that let you
 fine-tune what is allowed and what is not.  See the :ref:`Safe

--- a/start.rst
+++ b/start.rst
@@ -10,8 +10,8 @@ will be processed using JavaScript to produce HTML, SVG or MathML
 equations for viewing in any modern browser.
 
 There are two ways to access MathJax: the easiest way is to use the
-copy of MathJax available from our distributed network service at
-``cdn.mathjax.org``, but you can also download and install a copy of
+copy of MathJax available from a distributed network service such as
+``cdnjs.com``, but you can also download and install a copy of
 MathJax on your own server, or use it locally on your hard disk
 (with no need for network access).  All three of these are described
 below, with links to more detailed explanations.  This page gives the
@@ -21,32 +21,37 @@ setup for your pages.
 
 .. _mathjax-CDN:
 
-Using the MathJax Content Delivery Network (CDN)
-================================================
+Using a Content Delivery Network (CDN)
+======================================
 
-The easiest way to use MathJax is to link directly to the public
-installation available through the MathJax Content Distribution Network
-(CDN).  When you use the MathJax CDN, there is no need to install
+The easiest way to use MathJax is to link directly to a public
+installation available through a Content Distribution Network
+(CDN).  When you use a CDN, there is no need to install
 MathJax yourself, and you can begin using MathJax right away.
 
 The CDN will automatically arrange for your readers to download MathJax
-files from a fast, nearby server.  And since bug fixes and patches are
-deployed to the CDN as soon as they become available, your pages will
-always be up to date with the latest browser and devices.
+files from a fast, nearby server.
 
-To use MathJax from our server, you need to do two things:
+To use MathJax from a CDN, you need to do two things:
 
 1.  Link to MathJax in the web pages that are to include mathematics.
 
 2.  Put mathematics into your web pages so that MathJax can display
     it.
 
-To jump start, you accomplish the first step by putting
+.. warning:: 
+
+  We retired our self-hosted CDN at `cdn.mathjax.org` in April, 2017.
+  We recommend using `cdnjs.com <cdnjs.com>`_ which uses the same provider.
+  The use of ``cdn.mathjax.org`` was governed by its `terms of service
+  <https://www.mathjax.org/mathjax-cdn-terms-of-service/>`_.
+
+To jump start using `cdnjs`, you accomplish the first step by putting
 
 .. code-block:: html
 
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
 
 into the ``<head>`` block of your document.  (It can also go in the
@@ -62,41 +67,12 @@ mathematics.
 
   More details about the configuration process can be found in the :ref:`Loading and Configuring MathJax <loading>` instructions.
 
-The use of ``cdn.mathjax.org`` is governed by its `terms of service
-<https://www.mathjax.org/mathjax-cdn-terms-of-service/>`_, so be
-sure to read that before linking to the MathJax CDN server.
-
 .. note::
 
   To see how to enter mathematics in your web pages, see `Putting
   mathematics in a web page`_ below.
 
 .. _secure-cdn-access:
-
-Secure Access to the CDN
-------------------------
-
-If the MathJax CDN is accessed via the address ``http://cdn.mathjax.org`` (note
-the missing ``s`` after ``http``), the script is downloaded over a regular,
-insecure HTTP connection.  This poses a security risk as a malicious third
-party can intercept the MathJax script and replace it.  This is known as a
-`man-in-the-middle <https://en.wikipedia.org/wiki/Man-in-the-middle_attack>`_ attack.
-To prevent such attacks, one should access the MathJax CDN over a secure HTTPS
-connection, as demonstrated in the first example earlier.
-
-If the user wishes to use insecure HTTP to download the MathJax script if and
-only if the page itself is downloaded over insecure HTTP, then a
-protocol-relative address can be used to automatically switch between HTTP and
-HTTPS depending on what the current page uses:
-
-.. code-block:: html
-
-    <script type="text/javascript" async
-      src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-    </script>
-
-Note that this trick will not work if the page is accessed locally via ``file://``
-as it will attempt to load from ``file://cdn.mathjax.org`` instead.
 
 
 Putting mathematics in a web page
@@ -158,7 +134,7 @@ dollar-sign delimiters.
 
 Here is a complete sample page containing TeX mathematics (also
 available in the `test/sample-tex.html
-<https://cdn.mathjax.org/mathjax/latest/test/sample-tex.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/sample-tex.html>`_
 file):
 
 .. code-block:: html
@@ -171,7 +147,7 @@ file):
       MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
     </script>
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
+      src="https://example.com/MathJax.js?config=TeX-AMS_CHTML">
     </script>
     </head>
     <body>
@@ -249,7 +225,7 @@ situations.
 
 Here is a complete sample page containing MathML mathematics (also
 available in the `test/sample-mml.html
-<https://cdn.mathjax.org/mathjax/latest/test/sample-mml.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/sample-mml.html>`_
 file):
 
 .. code-block:: html
@@ -259,7 +235,7 @@ file):
     <head>
     <title>MathJax MathML Test Page</title>
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_CHTML">
+      src="https://example.com/MathJax.js?config=MML_CHTML">
     </script>
     </head>
     <body>
@@ -341,7 +317,7 @@ expressions written in this form by surrounding them in "back-ticks", i.e., ```.
 
 Here is a complete sample page containing AsciiMath notation (also
 available in the `test/sample-asciimath.html
-<https://cdn.mathjax.org/mathjax/latest/test/sample-asciimath.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/sample-asciimath.html>`_
 file):
 
 .. code-block:: html
@@ -351,7 +327,7 @@ file):
     <head>
     <title>MathJax AsciiMath Test Page</title>
     <script type="text/javascript" async
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=AM_CHTML"></script>
+      src="https://example.com/MathJax.js?config=AM_CHTML"></script>
     </head>
     <body>
 

--- a/tex.rst
+++ b/tex.rst
@@ -360,8 +360,7 @@ as a reference. For example,
 
 includes a labeled equation and a reference to that equation.  Note
 that references can come before the corresponding formula as well as
-after them.  See the equation numbering links in the `MathJax examples
-page <https://cdn.mathjax.org/mathjax/latest/test/examples.html>`_ for
+after them.  See the equation numbering pages in the `MathJax examples at <https://github.com/mathjax/MathJax/blob/master/test/>`_ for
 more examples.
 
 You can configure the way that numbers are displayed and how the
@@ -400,7 +399,7 @@ script prior to loading MathJax.  For example
       MathJax.Hub.Config({ TeX: { extensions: ["autobold.js"] }});
     </script>
     <script type="text/javascript"
-        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+        src="https://example.com/MathJax.js?config=TeX-AMS_HTML">
     </script>
 
 will load the `autobold` TeX extension in addition to those already
@@ -442,7 +441,7 @@ to be loaded, redefining all four to their proper values.  Note that
 this may be better than loading the extension explicitly, since it
 avoids loading the extra file on pages where these macros are *not*
 used.  The `sample autoloading macros
-<https://cdn.mathjax.org/mathjax/latest/test/sample-autoload.html>`_
+<https://github.com/mathjax/MathJax/blob/master/test/sample-autoload.html>`_
 example page shows this in action.  The `autoload-all` extension below
 defines such macros for *all* the extensions so that if you include
 it, MathJax will have access to all the macros it knows about.

--- a/upgrade.rst
+++ b/upgrade.rst
@@ -137,8 +137,8 @@ the inline math delimiters to include ``$...$`` in addition to
 ``\(...\)``, and would set the ``processEscapes`` parameter to ``true``.
 
 
-Loading MathJax from the CDN
-============================
+Loading MathJax from a CDN
+==========================
 
 The MathJax installation is fairly substantial (due to the large number of
 images needed for the image fonts), and so you may not want to (or be able
@@ -149,22 +149,7 @@ the best way for you to obtain MathJax.  That way you can be sure you are
 using an up-to-date version of MathJax, and that the server will be fast
 and reliable.
 
-To use the MathJax CDN service, simply load MathJax as follows:
-
-.. code-block:: html
-
-    <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-    </scrip>
-
-Of course, you can load any configuration file that you wish, or use a
-``text/x-mathajx-config`` block to configure MathJax in-line.
-:ref:`More details <loading-CDN>` are available, if you need them.
-
-The use of ``cdn.mathjax.org`` is governed by its `terms of service
-<https://www.mathjax.org/mathjax-cdn-terms-of-service.html>`_, so be
-sure to read that before linking to the MathJax CDN server.
-
+See :ref:`Loading MathJax from a CDN <loading-CDN>` for more information.
 
 Change in default TeX delimiters
 ================================


### PR DESCRIPTION
This PR changes the documents to reflect the loss of cdn.mathjax.org, and the suggested alternative of cdnjs.