### PR TITLE
Fixed typo in CDN url

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -124,7 +124,7 @@ always use the latest version of MathJax, you can use
 
 .. code-block::  sh
 
-  https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/lastes.js   # the latest release
+  https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/latest.js   # the latest release
 
 and MathJax will look up the lastest version and load that (regardless
 of the version number referenced in your URL).  That means you will


### PR DESCRIPTION
Hey folks,
I found a typo in a CDN url on this page: http://docs.mathjax.org/en/latest/configuration.html#loading-mathjax-from-a-cdn
I just fixed it and created this PR for you to review. I have not found any contributing guidelines, so please share that with me if I missed something on this PR.
Thanks!