### PR TITLE
Fixed an issue with a code example

### DIFF
--- a/web/typeset.rst
+++ b/web/typeset.rst
@@ -94,7 +94,7 @@ DOM modifications and returns the array of elements to typeset, or
    typeset(() => {
      const math = document.querySelector('#math');
      math.innerHTML = '$$\\frac{a}{1-a^2}$$';
-     return math;
+     return [math];
    });
 
 would replace the contents of the element with ``id="math"`` with the


### PR DESCRIPTION
An example returned document.querySelector result passed as a callback to the typeset() function which threw an exception because MathJax.typesetPromise() requires an iterable not just a Node. Changed the example to return an array with that node instead.