### PR TITLE
Document \data command

### DIFF
--- a/input/tex/extensions/autoload.rst
+++ b/input/tex/extensions/autoload.rst
@@ -135,7 +135,7 @@ The default autoload definitions are the following:
          enclose: ['enclose'],
          extpfeil: ['xtwoheadrightarrow', 'xtwoheadleftarrow', 'xmapsto',
                     'xlongequal', 'xtofrom', 'Newextarrow'],
-         html: ['href', 'class', 'style', 'cssId'],
+         html: ['data', 'href', 'class', 'style', 'cssId'],
          mhchem: ['ce', 'pu'],
          newcommand: ['newcommand', 'renewcommand', 'newenvironment', 'renewenvironment', 'def', 'let'],
          unicode: ['unicode'],

--- a/input/tex/extensions/html.rst
+++ b/input/tex/extensions/html.rst
@@ -5,7 +5,7 @@ html
 ####
 
 The `html` extension gives you access to some HTML features like
-styles, classes, element ID's, and clickable links.  It defines the
+styles, classes, element ID's, data-* attributes, and clickable links.  It defines the
 following non-standard macros:
 
 .. describe:: \\href{url}{math}
@@ -37,6 +37,10 @@ following non-standard macros:
     Adds the give ``css`` declarations to the element associated with
     ``math``.
 
+.. describe:: \\data{dataset}{math}
+
+    Adds `data-* <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*>`__ attributes to the element associated with ``math``.
+
 For example:
 
 .. code-block:: latex
@@ -46,6 +50,8 @@ For example:
     (x+1)^2 = \class{hidden}{(x+1)(x+1)}
 
     (x+1)^2 = \cssId{step1}{\style{visibility:hidden}{(x+1)(x+1)}}
+
+    x = \data{during="quadratic"}{\frac{-b\pm\sqrt{b^2-4ac}}{2a}}
 
 .. Note::
 
@@ -81,7 +87,7 @@ html Commands
 -------------
 
 The `html` extension implements the following macros:
-``\class``, ``\cssId``, ``\href``, ``\style``
+``\class``, ``\cssId``, ``\data``, ``\href``, ``\style``
 
 
 |-----|

--- a/input/tex/extensions/textmacros.rst
+++ b/input/tex/extensions/textmacros.rst
@@ -256,7 +256,8 @@ HTML Commands
 -------------
 
 .. list-table::
-
+   * - ``\data``
+     - specify data-* attributes
    * - ``\href``
      - make hyperlink
    * - ``\style``

--- a/input/tex/macros/index.rst
+++ b/input/tex/macros/index.rst
@@ -601,6 +601,8 @@ D
      - **ams**
    * - ``\dashv``
      -
+   * - ``\data``
+     - **html**
    * - ``\dbinom``
      - **ams**
    * - ``\dblcolon``


### PR DESCRIPTION
This PR adds documentation for the `data` command implemented in https://github.com/mathjax/MathJax-src/pull/791.