### PR TITLE
Typo fixes in typeset and start

### DIFF
--- a/web/start.rst
+++ b/web/start.rst
@@ -119,7 +119,7 @@ output format) to display the mathematics.
   The ``tex-mml-chtml.js`` file includes all the pieces needed for
   MathJax to process these two input formats and produce this
   output format.  There are several other choices with different
-  input/output combinations, and and you can even configure MathJax to
+  input/output combinations, and you can even configure MathJax to
   load components individually.
 
   We list this file here because it will get you started quickly with

--- a/web/typeset.rst
+++ b/web/typeset.rst
@@ -319,7 +319,7 @@ and then use
 
 in order to load the script when the page content is ready.  Note
 that you will want to include the path to the location where you
-stored ``check-mathjax.js``, that you should change
+stored ``check-for-tex.js``, that you should change
 ``tex-chtml.js`` to whatever component file you want to use, and that
 the ``window.MathJax`` value should be set to whatever configuration
 you want to use.  In this case, it just adds dollar signs to the


### PR DESCRIPTION
A couple of typos: (1) and and in start.rst, (2) "check-mathjax.js" should be "check-for-tex.js" in typeset.rst