### PR TITLE
Fix copypasta in an example in setoptions.rst

### DIFF
--- a/input/tex/extensions/setoptions.rst
+++ b/input/tex/extensions/setoptions.rst
@@ -66,8 +66,8 @@ To load the `setoptions` extension, add ``'[tex]/setoptions'`` to the
 .. code-block:: javascript
 
    window.MathJax = {
-     loader: {load: ['[tex]/centernot']},
-     tex: {packages: {'[+]': ['centernot']}}
+     loader: {load: ['[tex]/setoptions']},
+     tex: {packages: {'[+]': ['setoptions']}}
    };
 
 


### PR DESCRIPTION
A package load example for the `setoptions` extension loads the `centernot` package instead.