### PR TITLE
Extra ) in The Configuration Block

### DIFF
--- a/options/input/tex.rst
+++ b/options/input/tex.rst
@@ -42,7 +42,7 @@ The Configuration Block
         maxBuffer: 5 * 1024,       // maximum size for the internal TeX string (5K)
         baseURL:                   // URL for use with links to tags (when there is a <base> tag in effect)
            (document.getElementsByTagName('base').length === 0) ?
-            '' : String(document.location).replace(/#.*$/, '')),
+            '' : String(document.location).replace(/#.*$/, ''),
         formatError:               // function called when TeX syntax errors occur
             (jax, err) => jax.formatError(err)
       }


### PR DESCRIPTION
Currently, there is an extra `)` at the end of the value portion of the `baseURL` parameter. 
```
    baseURL:                   // URL for use with links to tags (when there is a <base> tag in effect)
       (document.getElementsByTagName('base').length === 0) ?
        '' : String(document.location).replace(/#.*$/, '')),
```

If the code is copied and tested as it currently is in the docs, it results in the following error in the console:
Uncaught SyntaxError: missing } after property list test.html:31:63
note: { opened at line 9, column 12test.html:9:12

While this seems quite benign, the problem is that parameter changes before this invalid line are ignored. For example, setting `maxBuffer: 50 * 1024` does not get implemented due to the error which can lead to confusion. 